### PR TITLE
feat: add borrow book form page with fees calculation and breadcrumb

### DIFF
--- a/frontendNext/app/borrow/[id]/page.tsx
+++ b/frontendNext/app/borrow/[id]/page.tsx
@@ -1,0 +1,142 @@
+
+"use client";
+
+import { useParams, useRouter } from "next/navigation";
+import { useState } from "react";
+import { getBookById, getUserById } from "@/app/data/mockData";
+import Breadcrumb from "@/app/components/ui/Breadcrumb";
+import Button from "@/app/components/ui/Button";
+import Input from "@/app/components/ui/Input";
+
+export default function BorrowPage() {
+  const { id } = useParams();
+  const router = useRouter();
+  const book = getBookById(id as string);
+
+  if (!book) {
+    return (
+      <div className="p-6 text-center">
+        <h2 className="text-lg font-medium text-gray-900 mb-4">Book not found</h2>
+        <Button variant="primary" onClick={() => router.push("/books")}>
+          Back to Books
+        </Button>
+      </div>
+    );
+  }
+
+  const owner = getUserById(book.ownerId);
+
+  const [form, setForm] = useState({
+    shippingWay: "delivery",
+    deliveryAddress: "",
+  });
+
+  // calculate fees
+  const fees = {
+    deposit: book.fees.deposit,
+    serviceFee: book.fees.serviceFee,
+    shipping: form.shippingWay === "delivery" ? book.fees.estimatedShipping : 0,
+  };
+  const total = fees.deposit + fees.serviceFee + fees.shipping;
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+    setForm((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log("Borrow confirmed:", {
+      bookId: id,
+      bookTitle: book.title,
+      ...form,
+      total,
+    });
+    // TODO: Call the API → Create an order
+  };
+
+  return (
+    <div className="p-6">
+      <Breadcrumb
+        items={[
+          { label: "Books", href: "/books" },
+          { label: book.title, href: `/books/${book.id}` },
+          { label: "Borrow" },
+        ]}
+      />
+
+      <div className="max-w-2xl mx-auto p-6">
+        {/* Title */}
+        <h1 className="text-2xl font-bold text-gray-900 mb-4">{book.title}</h1>
+        <p className="text-gray-600 mb-6">Borrow it from {owner?.name || "Platform User"}</p>
+
+        <form
+          onSubmit={handleSubmit}
+          className="bg-white shadow rounded-lg p-6 space-y-6"
+        >
+          {/* Shipping Way */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Shipping Way
+            </label>
+            <select
+              name="shippingWay"
+              value={form.shippingWay}
+              onChange={handleChange}
+              className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:ring-2 focus:ring-black"
+            >
+              <option value="pickup">Pickup in person</option>
+              <option value="delivery">Delivery</option>
+            </select>
+          </div>
+
+          {/* Delivery Address */}
+          {form.shippingWay === "delivery" && (
+            <Input
+              label="Delivery Address"
+              name="deliveryAddress"
+              value={form.deliveryAddress}
+              onChange={handleChange}
+              placeholder="Enter delivery address"
+              required
+            />
+          )}
+
+          {/* Fees & Costs */}
+          <div className="border rounded-lg p-4 bg-gray-50">
+            <h3 className="text-gray-900 font-medium mb-4">Fees & Costs</h3>
+            <div className="flex justify-between mb-2">
+              <span>Deposit (refundable)</span>
+              <span>${fees.deposit}</span>
+            </div>
+            <div className="flex justify-between mb-2">
+              <span>Platform Service Fee</span>
+              <span>${fees.serviceFee}</span>
+            </div>
+            {form.shippingWay === "delivery" && (
+              <div className="flex justify-between mb-2">
+                <span>Estimated Shipping</span>
+                <span>${fees.shipping}</span>
+              </div>
+            )}
+            <div className="flex justify-between font-bold text-lg border-t pt-2">
+              <span>Total Expected Cost</span>
+              <span>${total}</span>
+            </div>
+            <p className="text-gray-500 text-xs mt-2">
+              Deposits are refundable upon book return in good condition. 
+              Service fees and shipping costs are non-refundable.
+            </p>
+          </div>
+
+          {/* Submit */}
+          <div className="flex justify-end">
+            <Button type="submit" variant="primary" size="md" fullWidth>
+              Confirm And Pay
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/frontendNext/app/components/filters/BookFilter.tsx
+++ b/frontendNext/app/components/filters/BookFilter.tsx
@@ -29,9 +29,9 @@ const BookFilter: React.FC<BookFilterProps> = ({
   // Extract unique categories and languages from books data
   const allCategories = [...new Set(books.map((book) => book.category))];
   const allLanguages = [...new Set(books.map((book) => book.language))];
-  const allGenres = [...new Set(books.flatMap((book) => book.genre))];
+  const allTags = [...new Set(books.flatMap((book) => book.tags))];
 
-  // Count frequency of each category, language, and genre
+  // Count frequency of each category, language, and tags
   const categoryCount = allCategories.map((category) => ({
     name: category,
     count: books.filter((book) => book.category === category).length,
@@ -42,9 +42,9 @@ const BookFilter: React.FC<BookFilterProps> = ({
     count: books.filter((book) => book.language === language).length,
   }));
 
-  const genreCount = allGenres.map((genre) => ({
-    name: genre,
-    count: books.filter((book) => book.genre.includes(genre)).length,
+  const tagsCount = allTags.map((tags) => ({
+    name: tags,
+    count: books.filter((book) => book.tags.includes(tags)).length,
   }));
 
   // Sort by frequency (most common first) and take top 5
@@ -58,7 +58,7 @@ const BookFilter: React.FC<BookFilterProps> = ({
     .slice(0, 5)
     .map((item) => item.name);
 
-  const topGenres = genreCount
+  const topTags = tagsCount
     .sort((a, b) => b.count - a.count)
     .slice(0, 8)
     .map((item) => item.name);
@@ -194,19 +194,19 @@ const BookFilter: React.FC<BookFilterProps> = ({
         </div>
       </div>
 
-      {/* Genres Section */}
+      {/* Tags Section */}
       <div>
         <h4 className="text-sm font-medium text-gray-900 mb-3 flex items-center">
           <Tag className="w-4 h-4 mr-2" />
-          Genres ({topGenres.length})
+          Tags ({topTags.length})
         </h4>
         <div className="flex flex-wrap gap-2">
-          {topGenres.map((genre) => (
+          {topTags.map((tags) => (
             <button
-              key={genre}
+              key={tags}
               className="px-2 py-1 text-xs bg-gray-100 text-gray-700 rounded-full hover:bg-gray-200"
             >
-              {genre}
+              {tags}
             </button>
           ))}
         </div>

--- a/frontendNext/app/components/ui/Breadcrumb.tsx
+++ b/frontendNext/app/components/ui/Breadcrumb.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { ChevronRight } from "lucide-react";
+
+export interface BreadcrumbItem {
+  label: string;
+  href?: string; // 没有 href 表示当前页面
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[];
+}
+
+export default function Breadcrumb({ items }: BreadcrumbProps) {
+  return (
+    <nav aria-label="Breadcrumb" className="text-sm text-gray-500 mb-4">
+      <ol className="flex items-center space-x-1">
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1;
+          return (
+            <li key={index} className="flex items-center">
+              {!isLast && item.href ? (
+                <Link
+                  href={item.href}
+                  className="hover:underline text-gray-600"
+                >
+                  {item.label}
+                </Link>
+              ) : (
+                <span className="text-gray-700">{item.label}</span>
+              )}
+
+              {!isLast && (
+                <ChevronRight className="w-4 h-4 mx-1 text-gray-400" />
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/frontendNext/app/data/mockData.tsx
+++ b/frontendNext/app/data/mockData.tsx
@@ -17,7 +17,6 @@ export interface Book {
   isbn?: string;
   publishYear?: number;
   tags: string[];
-  genre: string[];
   availableFrom?: string;
   maxLendingDays: number;
   deliveryMethod: "post" | "self-help" | "both";
@@ -224,7 +223,6 @@ export const mockBooks: Book[] = [
     dateAdded: "2024-01-15",
     language: "English",
     publishYear: 2020,
-    genre: ["Contemporary Fiction", "Philosophy"],
     tags: ["life choices", "parallel lives", "self-reflection", "existential"],
     maxLendingDays: 21,
     availableFrom: "2024-02-01",
@@ -250,7 +248,6 @@ export const mockBooks: Book[] = [
     dateAdded: "2024-01-20",
     language: "English",
     publishYear: 2018,
-    genre: ["Personal Development", "Psychology"],
     tags: ["habits", "productivity", "self-improvement", "psychology"],
     maxLendingDays: 14,
     deliveryMethod: "post",
@@ -277,7 +274,6 @@ export const mockBooks: Book[] = [
     dueDate: "2024-02-15",
     language: "English",
     publishYear: 1965,
-    genre: ["Science Fiction", "Space Opera", "Politics"],
     tags: ["desert planet", "politics", "mysticism", "classic sci-fi"],
     maxLendingDays: 30,
     deliveryMethod: "self-help",
@@ -303,7 +299,6 @@ export const mockBooks: Book[] = [
     dueDate: "2024-02-15",
     language: "English",
     publishYear: 1965,
-    genre: ["Science Fiction", "Space Opera", "Politics"],
     tags: ["desert planet", "politics", "mysticism", "classic sci-fi"],
     maxLendingDays: 30,
     deliveryMethod: "self-help",
@@ -327,7 +322,6 @@ export const mockBooks: Book[] = [
     dateAdded: "2024-01-10",
     language: "English",
     publishYear: 2017,
-    genre: ["Historical Fiction", "LGBTQ+", "Romance"],
     tags: ["Hollywood", "biography", "love story", "secrets"],
     maxLendingDays: 21,
     deliveryMethod: "both",
@@ -352,7 +346,6 @@ export const mockBooks: Book[] = [
     dateAdded: "2024-01-05",
     language: "English",
     publishYear: 2011,
-    genre: ["History", "Anthropology", "Philosophy"],
     tags: [
       "human evolution",
       "civilization",
@@ -382,7 +375,6 @@ export const mockBooks: Book[] = [
     dateAdded: "2024-01-25",
     language: "English",
     publishYear: 2021,
-    genre: ["Science Fiction", "Space Opera", "Adventure"],
     tags: ["space", "mystery", "survival", "humor"],
     maxLendingDays: 21,
     deliveryMethod: "both",
@@ -407,7 +399,6 @@ export const mockBooks: Book[] = [
     dateAdded: "2024-01-18",
     language: "English",
     publishYear: 1987,
-    genre: ["Literary Fiction", "Romance", "Coming of Age"],
     tags: ["Tokyo", "1960s", "love", "memory", "Japanese literature"],
     maxLendingDays: 21,
     deliveryMethod: "both",
@@ -432,7 +423,6 @@ export const mockBooks: Book[] = [
     dateAdded: "2024-01-22",
     language: "English",
     publishYear: 1988,
-    genre: ["Design", "Psychology", "Technology"],
     tags: ["UX design", "usability", "human-centered design", "technology"],
     maxLendingDays: 21,
     deliveryMethod: "self-help",
@@ -456,7 +446,6 @@ export const mockBooks: Book[] = [
     dateAdded: "2024-01-12",
     language: "English",
     publishYear: 2018,
-    genre: ["Memoir", "Biography", "Education"],
     tags: ["education", "family", "resilience", "transformation"],
     maxLendingDays: 25,
     deliveryMethod: "both",
@@ -481,7 +470,6 @@ export const mockBooks: Book[] = [
     dateAdded: "2024-01-08",
     language: "English",
     publishYear: 2018,
-    genre: ["Literary Fiction", "Mystery", "Coming of Age"],
     tags: ["nature", "mystery", "isolation", "coming of age"],
     maxLendingDays: 21,
     deliveryMethod: "post",
@@ -506,7 +494,6 @@ export const mockBooks: Book[] = [
     dateAdded: "2024-01-14",
     language: "English",
     publishYear: 1988,
-    genre: ["Philosophical Fiction", "Adventure", "Spiritual"],
     tags: ["dreams", "journey", "philosophy", "self-discovery"],
     maxLendingDays: 18,
     deliveryMethod: "both",
@@ -531,7 +518,6 @@ export const mockBooks: Book[] = [
     dateAdded: "2024-01-06",
     language: "English",
     publishYear: 1949,
-    genre: ["Dystopian Fiction", "Political Fiction", "Classic"],
     tags: ["dystopia", "surveillance", "freedom", "classic literature"],
     maxLendingDays: 28,
     deliveryMethod: "self-help",
@@ -555,7 +541,6 @@ export const mockBooks: Book[] = [
     dateAdded: "2024-01-30",
     language: "English",
     publishYear: 2018,
-    genre: ["Memoir", "Biography", "Politics"],
     tags: ["inspiration", "leadership", "family", "politics"],
     maxLendingDays: 21,
     deliveryMethod: "both",
@@ -671,6 +656,11 @@ export const getUserById = (userId: string): User | undefined => {
 export const getCurrentUser = (): User => {
   return mockUsers[0]; // user1 is Zhenyi Su
 };
+
+// Helper function to get book data by ID
+export function getBookById(id: string) {
+  return mockBooks.find((book) => book.id === id);
+}
 
 // Helper function to get user's lending orders
 export const getUserLendingOrders = (userId: string): Order[] => {

--- a/frontendNext/package-lock.json
+++ b/frontendNext/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "capstone-project",
+  "name": "bookhive",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "capstone-project",
+      "name": "bookhive",
       "version": "0.1.0",
       "dependencies": {
         "@tailwindcss/postcss": "^4.1.12",


### PR DESCRIPTION
📝 Summary

Added Borrow Book Form Page under /borrow/[id]

Integrated with getBookById and getUserById

Dynamically calculates fees (deposit, serviceFee, estimatedShipping) from book data

Added Breadcrumb component for better navigation UX

🔧 Changes

app/borrow/[id]/page.tsx → new form page

> Shows book info and owner

> Select shipping method (pickup / delivery)

> Input delivery address (only for delivery)

> Display dynamic fees & total cost

> Submit button (Confirm and Pay)

app/components/ui/Breadcrumb.tsx → reusable breadcrumb component

Integrated Button and Input UI components for consistent styling

Deleted "Genre" from the books DB as well as in components/filters/Bookfilters.tsx

📸 Screenshots

<img width="1412" height="738" alt="Screenshot 2025-08-27 at 4 38 37 pm" src="https://github.com/user-attachments/assets/d0206406-5f67-4624-bb9c-6a086e01bc61" />


✅ Test Cases

 Navigate /borrow/[id] works

 Form submits with correct bookId, bookTitle, shippingWay, and fees

 Fees update correctly when changing shipping method

 Breadcrumb renders correct path (Books > Title > Borrow)

📌 Next Steps (Future Work)

Integrate with Orders API / mockOrders → save borrow requests

Add Book Detail page `books/[id]`

Add Borrow Orders List `/borrow/list` and Order Details `/borrow/[id]/detail`