### PR TITLE
feat-CRUD: Add Book frontend feature

### DIFF
--- a/frontendNext/app/books/[id]/page.tsx
+++ b/frontendNext/app/books/[id]/page.tsx
@@ -12,7 +12,9 @@ import {
   MessageCircle,
   Package,
   Shield,
-  ShoppingBag
+  ShoppingBag,
+  Book,
+  Languages,
 } from "lucide-react";
 import Card from "../../components/ui/Card";
 import Button from "../../components/ui/Button";
@@ -25,7 +27,8 @@ import {
 } from "@/app/data/mockData";
 
 import Avatar from "@/app/components/ui/Avatar";
-
+import { useCartStore } from "@/app/store/cartStore";
+import { toast } from 'sonner';
 
 export default function BookDetailPage() {
   const params = useParams();
@@ -47,7 +50,7 @@ export default function BookDetailPage() {
   const currentUser = getCurrentUser();
 
   const distance = useMemo(() => {
-    if (!owner || !owner.coordinates) return 0;
+    if (!owner?.coordinates || !currentUser?.coordinates) return 0;
     return calculateDistance(
       currentUser.coordinates.lat,
       currentUser.coordinates.lng,
@@ -101,6 +104,9 @@ export default function BookDetailPage() {
         return "text-gray-600 bg-gray-50 border-gray-200";
     }
   };
+
+  const formatKm = (km: number) =>
+    km >= 100 ? `${Math.round(km)} km` : `${km.toFixed(1)} km`;
 
   const addToCart = useCartStore((state) => state.addToCart);
 
@@ -166,30 +172,30 @@ export default function BookDetailPage() {
 
                 <div className="p-4 space-y-3">
                   <Button
-    onClick={() => {
-      const ok = useCartStore.getState().addToCart(book, "borrow"); // 👈 指定首选租赁
-      if (ok) {
-        toast?.success?.("Added to cart");
-      } else {
-        toast?.error?.("This book cannot be requested (rent not available).");
-      }
-    }}
-    className="w-full flex items-center justify-center space-x-2"
-    disabled={
-      book.status !== "listed" || (!book.canRent && !book.canSell)
-    } // 👈 同时考虑能力
-  >
-    <ShoppingBag className="w-4 h-4" />
-    <span>
-      {book.status !== "listed"
-        ? "Unlisted"
-        : book.canRent
-        ? "Request This Book"
-        : book.canSell
-        ? "Purchase Only"
-        : "Unavailable"}
-    </span>
-  </Button>
+                    onClick={() => {
+                      const ok = useCartStore.getState().addToCart(book, "borrow"); // 指定首选租赁
+                      if (ok) {
+                        toast?.success?.("Added to cart");
+                      } else {
+                        toast?.error?.("This book cannot be requested (rent not available).");
+                      }
+                    }}
+                    className="w-full flex items-center justify-center space-x-2"
+                    disabled={
+                      book.status !== "listed" || (!book.canRent && !book.canSell)
+                    }
+                  >
+                    <ShoppingBag className="w-4 h-4" />
+                    <span>
+                      {book.status !== "listed"
+                        ? "Unlisted"
+                        : book.canRent
+                          ? "Request This Book"
+                          : book.canSell
+                            ? "Purchase Only"
+                            : "Unavailable"}
+                    </span>
+                  </Button>
 
 
                   <Button
@@ -236,23 +242,39 @@ export default function BookDetailPage() {
                   </p>
                 </div>
 
+                <h4 className="font-semibold text-gray-900 mb-3">Book Information</h4>
+
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+
                   <div>
-                    <h4 className="font-semibold text-gray-900 mb-3">Book Information</h4>
                     <div className="space-y-2 text-sm">
                       <div className="flex justify-between">
-                        <span className="text-gray-500">Category:</span>
+                        <span className="text-gray-500 flex items-center gap-1">
+                          <Book className="w-4 h-4" />
+                        Category:</span>
                         <span className="font-medium">{book.category}</span>
                       </div>
                       <div className="flex justify-between">
-                        <span className="text-gray-500">Language:</span>
+                        <span className="text-gray-500 flex items-center gap-1">
+                          <Languages className="w-4 h-4" />
+                        Language:</span>
                         <span className="font-medium">{book.originalLanguage}</span>
+                      </div>
+                      <div className="flex justify-between">
+                        <span className="text-gray-500 flex items-center gap-1">
+                          <ShoppingBag className="w-4 h-4" />
+                          Trading Way:</span>
+                        <span className="font-medium">
+                          {book.canRent ? "Borrow" : ""}
+                          {book.canSell ? (book.canRent ? " / Buy" : "Buy") : ""}
+                          {(!book.canRent && !book.canSell) && "Unavailable"}
+                        </span>
                       </div>
                     </div>
                   </div>
 
                   <div>
-                    <h4 className="font-semibold text-gray-900 mb-3">Lending Details</h4>
+
                     <div className="space-y-2 text-sm">
                       <div className="flex items-center justify-between">
                         <span className="text-gray-500 flex items-center gap-1">
@@ -283,13 +305,24 @@ export default function BookDetailPage() {
               <Card>
                 <h3 className="text-lg font-semibold text-gray-900 mb-4">Book Owner</h3>
                 <div className="flex items-center space-x-4">
-                  <Avatar user={currentUser} size={96} />
+                  <Avatar user={owner} size={64} />
 
                   <div className="flex-1">
                     <h4 className="font-semibold text-gray-900">{owner.name}</h4>
                     <div className="flex items-center text-gray-600 text-sm mt-1">
                       <MapPin className="w-4 h-4 mr-1" />
-                      <span>{owner.location}  {distance}km away</span>
+                      <p>
+                        {[
+                          owner.city,
+                          owner.state,
+                          owner.zipCode,
+                          owner.country,
+                        ].filter(Boolean).join(", ")}
+                      </p>
+                      <div>
+                        {distance > 0 ? ` • ${formatKm(distance)} away from you` : ""}
+                      </div>
+
                     </div>
                     <div className="flex items-center mt-2">
                       <div className="flex items-center mr-3">
@@ -304,7 +337,7 @@ export default function BookDetailPage() {
                         ))}
                       </div>
                       <span className="text-sm text-gray-600">
-                        {owner.rating} ({owner.booksLent} books lent)
+                        {owner.rating}
                       </span>
                     </div>
                   </div>

--- a/frontendNext/app/components/layout/Header.tsx
+++ b/frontendNext/app/components/layout/Header.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import Button from "../ui/Button";
 import Input from "../ui/Input";
-import { User, LogOut, Plus, Truck, LifeBuoy, ShoppingBag } from "lucide-react";
+import { User as UserIcon, LogOut, Plus, Truck, LifeBuoy, ShoppingBag } from "lucide-react";
 import {
   logoutUser,
   isAuthenticated,
@@ -14,8 +14,7 @@ import {
 
 import Avatar from "@/app/components/ui/Avatar";
 import { useCartStore } from "@/app/store/cartStore";
-
-
+import type { User } from "@/app/types/user";
 
 
 const Header: React.FC = () => {
@@ -23,14 +22,7 @@ const Header: React.FC = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [showProfileMenu, setShowProfileMenu] = useState(false);
-  const [currentUser, setCurrentUser] = useState<{
-    id: string;
-    name: string;
-    email: string;
-    location: string;
-    avatar: string;
-    createdAt: string;
-  } | null>(null);
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
 
   // Check authentication status on component mount and when auth changes
   useEffect(() => {
@@ -170,7 +162,6 @@ const Header: React.FC = () => {
             {/* Shopping Cart button - count items */}
             <div className="flex items-center space-x-4">
               <HeaderCart />
-              {/* 这里可以继续放 User / Login 按钮 */}
             </div>
 
             {/* User profile section - shown when logged in */}
@@ -197,7 +188,7 @@ const Header: React.FC = () => {
                       className="flex items-center px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
                       onClick={() => setShowProfileMenu(false)}
                     >
-                      <User className="w-4 h-4 mr-3" />
+                      <UserIcon className="w-4 h-4 mr-3" />
                       View Profile
                     </Link>
 

--- a/frontendNext/app/components/ui/Avatar.tsx
+++ b/frontendNext/app/components/ui/Avatar.tsx
@@ -2,7 +2,12 @@ import React from "react";
 import type { User } from "@/app/types/user";
 
 interface AvatarProps {
-  user: User;
+  user: {
+    firstName?: string;
+    lastName?: string;
+    avatar?: string;
+    profilePicture?: string;
+  };
   size?: number; // 默认 40px
   className?: string;
 }

--- a/frontendNext/app/data/mockData.tsx
+++ b/frontendNext/app/data/mockData.tsx
@@ -2,26 +2,6 @@
 import { User } from "@/app/types/user";
 import { Book } from "@/app/types/book";
 
-// export interface User {
-//   id: string;
-//   name: string;
-//   email: string;
-//   location: string;
-//   address?: string; // Full address for postal delivery
-//   coordinates: {
-//     lat: number;
-//     lng: number;
-//   };
-//   rating: number;
-//   booksLent: number;
-//   booksBorrowed: number;
-//   joinDate: string;
-//   bio: string;
-//   avatar: string;
-//   preferredLanguages: string[];
-//   maxDistance: number; // kilometers willing to travel
-// }
-
 export interface LendingRequest {
   id: string;
   bookId: string;
@@ -107,6 +87,7 @@ export const mockUsers: User[] = [
     id: "user1",
     firstName: "Alice",
     lastName: "Wang",
+    name: "Alice Wang",
     email: "alice@example.com",
     phoneNumber: "+61 400 123 456",
     dateOfBirth: { month: "03", day: "12", year: "1995" },
@@ -117,7 +98,7 @@ export const mockUsers: User[] = [
     zipCode: "2000",
     coordinates: { lat: -33.8688, lng: 151.2093 },
     maxDistance: 10,
-    avatar: "/images/users/alice.jpg",
+    avatar: "",
     bio: "Avid reader who loves fiction and sharing books with the community.",
     preferredLanguages: ["English", "Mandarin"],
     createdAt: new Date("2023-01-10"),
@@ -126,6 +107,7 @@ export const mockUsers: User[] = [
     id: "user2",
     firstName: "David",
     lastName: "Chen",
+    name: "David Chen",
     email: "david@example.com",
     phoneNumber: "+61 433 987 654",
     dateOfBirth: { month: "07", day: "24", year: "1990" },
@@ -136,7 +118,7 @@ export const mockUsers: User[] = [
     zipCode: "3000",
     coordinates: { lat: -37.8136, lng: 144.9631 },
     maxDistance: 20,
-    avatar: "/images/users/david.jpg",
+    avatar: "",
     bio: "Collector of classic literature. Always open to lend and borrow.",
     preferredLanguages: ["English"],
     createdAt: new Date("2023-02-05"),
@@ -145,6 +127,7 @@ export const mockUsers: User[] = [
     id: "user3",
     firstName: "Sophia",
     lastName: "Li",
+    name: "Sophia Li",
     email: "sophia@example.com",
     phoneNumber: "+61 422 765 321",
     dateOfBirth: { month: "11", day: "05", year: "1998" },
@@ -155,7 +138,7 @@ export const mockUsers: User[] = [
     zipCode: "4000",
     coordinates: { lat: -27.4698, lng: 153.0251 },
     maxDistance: 15,
-    avatar: "/images/users/sophia.jpg",
+    avatar: "",
     bio: "Passionate about fantasy novels and community sharing.",
     preferredLanguages: ["English", "Japanese"],
     createdAt: new Date("2023-03-12"),

--- a/frontendNext/app/layout.tsx
+++ b/frontendNext/app/layout.tsx
@@ -24,7 +24,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
+    <html>
       <body
         className={`${geistSans.variable} ${geistMono.variable} min-h-screen flex flex-col bg-gray-100`}
       >

--- a/frontendNext/app/lend/add/page.tsx
+++ b/frontendNext/app/lend/add/page.tsx
@@ -3,28 +3,36 @@
 import { useState } from "react";
 import Input from "@/app/components/ui/Input";
 import Button from "@/app/components/ui/Button";
-import { mockBooks } from "@/app/data/mockData";
 import { Book } from "@/app/types/book";
+import { createBook } from "@/utils/auth";
+import { getCurrentUser } from "@/utils/auth";
+import { useRouter } from "next/navigation";
+
 
 export default function LendBookPage() {
   const [form, setForm] = useState({
-    titleOrigin: "",
-    language: "",
+    titleOr: "",
     titleEn: "",
+    originalLanguage: "",
     author: "",
     category: "",
     description: "",
     coverImage: null as File | null,
     tags: "",
-    depositPrice: "",
+    deposit: "",
+    salePrice: "",
     lendDuration: "",
     condition: "like-new",
     conditionImages: [] as File[],
     isbn: "",
     publishYear: "",
-    shippingPickup: false,
-    shippingDelivery: false,
+    deliveryMethod: "",
+    canRent: true,
+    canSell: false,
   });
+
+  const [showErrors, setShowErrors] = useState(false);
+const router = useRouter();
 
   const handleChange = (
     e: React.ChangeEvent<
@@ -32,39 +40,46 @@ export default function LendBookPage() {
     >
   ) => {
     const { name, value, type, checked } = e.target as HTMLInputElement;
+
     setForm((prev) => ({
       ...prev,
       [name]: type === "checkbox" ? checked : value,
     }));
   };
 
+
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0] || null;
     setForm((prev) => ({ ...prev, coverImage: file }));
   };
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
-    // check Shipping Way
-    if (!form.shippingPickup && !form.shippingDelivery) {
+    if (!form.deliveryMethod) {
       setShowErrors(true);
       return;
     }
 
-    // create a Book
+     const user = await getCurrentUser();
+  if (!user?.id) {
+    alert("Please login first.");
+    return;
+  }
+    // 1. create a Book
     const newBook: Book = {
       id: `book-${Date.now()}`,
-      titleOr: form.titleOrigin,
+      titleOr: form.titleOr,
       titleEn: form.titleEn || "",
-      originalLanguage: form.language,
+      originalLanguage: form.originalLanguage,
       author: form.author,
       category: form.category,
       description: form.description,
       coverImgUrl: form.coverImage
         ? URL.createObjectURL(form.coverImage)
         : "https://via.placeholder.com/300x400?text=No+Cover",
-      ownerId: "user1", // TODO: 替换为当前登录用户
+
+      ownerId: user.id,
 
       status: "listed",
       condition: form.condition as Book["condition"],
@@ -80,313 +95,399 @@ export default function LendBookPage() {
       tags: form.tags.split(",").map((k) => k.trim()).filter(Boolean),
       maxLendingDays: Number(form.lendDuration) || 14,
 
-      deliveryMethod:
-        form.shippingPickup && form.shippingDelivery
-          ? "both"
-          : form.shippingPickup
-            ? "self-help"
-            : "post",
+      deliveryMethod: form.deliveryMethod as Book["deliveryMethod"],
+      canRent: form.canRent,
+      canSell: form.canSell,
 
-      fees: {
-        deposit: Number(form.depositPrice),
-        serviceFee: 3,
-        estimatedShipping: form.shippingDelivery ? 8 : undefined,
-      },
+      salePrice: form.salePrice ? Number(form.salePrice) : undefined,
+      deposit: form.deposit ? Number(form.deposit) : undefined,
     };
 
+    try {
+      // 2. Call the backend interface
+      const created = await createBook(newBook);
 
-    // save
-    mockBooks.push(newBook);
+      // 3. feedback
+      console.log("Book created:", created);
+      alert("Book has been listed successfully!");
 
-    console.log("New book added:", newBook);
-    alert("Book has been listed successfully!");
+    
+    router.push(`/books/${created.id}`);
+    } catch (error) {
+      console.error("Failed to create book:", error);
+      alert("Failed to list book.");
+    }
+
   };
 
-  const [showErrors, setShowErrors] = useState(false);
 
   return (
-    <div className="max-w-2xl mx-auto p-6">
-      <h1 className="text-2xl font-bold text-gray-900 mb-6">Start Lending</h1>
+    <div className="max-w-6xl mx-auto p-6">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-2">Start Lending</h1>
+        <p className="text-gray-600"> List your books for rent or sale and make them available to the community.</p>
+      </div>
 
       <form
         onSubmit={handleSubmit}
-        className="bg-white shadow rounded-lg p-6 space-y-6"
+        className="bg-white shadow rounded-lg p-6"
       >
-        {/* Title + Language */}
-        <div className="flex gap-2 items-start">
-          <Input
-            label="Title - Origin*"
-            name="titleOrigin"
-            value={form.titleOrigin}
-            onChange={handleChange}
-            required
-          />
-          <div className="w-40">
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              Language
-            </label>
-            <select
-              name="Language*"
-              value={form.language}
-              onChange={handleChange}
-              className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
-            >
-              <option value="">Select</option>
-              <option value="English">English</option>
-              <option value="Chinese">Chinese</option>
-              <option value="Japanese">Japanese</option>
-            </select>
-          </div>
-        </div>
+        <div className="lg:flex lg:divide-x lg:divide-gray-200">
 
-        {/* Title En */}
-        <Input
-          label="Title - En*"
-          name="titleEn"
-          value={form.titleEn}
-          onChange={handleChange}
-          required
-        />
+          {/* left：基本信息 / 元信息 / 图片 */}
+          <div className="lg:w-1/2 lg:pr-8 space-y-6">
 
-        {/* Author */}
-        <Input
-          label="Author*"
-          name="author"
-          value={form.author}
-          onChange={handleChange}
-          required
-        />
-
-        {/* Category */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
-            Category*
-          </label>
-          <select
-            name="category"
-            value={form.category}
-            onChange={handleChange}
-            className="w-full border border-gray-300 rounded-lg px-3 py-2"
-            required
-          >
-            <option value="">Please choose a category</option>
-            <option value="Fiction">Fiction</option>
-            <option value="Sci-Fi">Sci-Fi</option>
-            <option value="Non-Fiction">Non-Fiction</option>
-          </select>
-        </div>
-
-        {/* Description */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
-            Description*
-          </label>
-          <textarea
-            name="description"
-            value={form.description}
-            onChange={handleChange}
-            rows={4}
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-black"
-            required
-          />
-        </div>
-
-        {/* Tags */}
-        <Input
-          label="Tags (separate by ,)"
-          name="Tags"
-          value={form.tags}
-          onChange={handleChange}
-        />
-
-        {/* ISBN */}
-        <Input
-          label="ISBN"
-          name="isbn"
-          value={form.isbn}
-          onChange={handleChange}
-          placeholder="Optional-International Standard Book Number"
-        />
-
-        {/* Publish Year */}
-        <Input
-          label="Publish Year"
-          name="publishYear"
-          value={form.publishYear}
-          onChange={handleChange}
-          placeholder="e.g. 2020"
-        />
-
-        {/* Cover Image */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
-            Cover Image
-          </label>
-
-          <div className="flex items-center gap-4">
-            {/* 隐藏的 input */}
-            <input
-              type="file"
-              id="cover-upload"
-              accept="image/*"
-              onChange={handleFileChange}
-              className="hidden"
-            />
-
-            {/* upload button */}
-            <Button
-              type="button"
-              variant="secondary"
-              size="sm"
-              onClick={() => document.getElementById("cover-upload")?.click()}
-            >
-              Upload Image
-            </Button>
-
-            {/* preview */}
-            {form.coverImage && (
-              <img
-                src={URL.createObjectURL(form.coverImage)}
-                alt="Preview"
-                className="h-20 w-16 object-cover rounded border"
+            {/* Title + Language */}
+            <div className="flex gap-2 items-start">
+              <Input
+                label="Title - Origin*"
+                name="titleOr"
+                value={form.titleOr}
+                onChange={handleChange}
+                required
               />
-            )}
-          </div>
-        </div>
+              <div className="w-40">
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Language
+                </label>
+                <select
+                  name="originalLanguage"
+                  value={form.originalLanguage}
+                  onChange={handleChange}
+                  className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm"
+                  required
+                >
+                  <option value="">Select</option>
+                  <option value="English">English</option>
+                  <option value="Chinese">Chinese</option>
+                  <option value="Japanese">Japanese</option>
+                </select>
 
-        {/* Condition */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
-            Condition*
-          </label>
-          <select
-            name="condition"
-            value={form.condition}
-            onChange={handleChange}
-            className="w-full border border-gray-300 rounded-lg px-3 py-2"
-            required
-          >
-            <option value="new">New</option>
-            <option value="like-new">Like New</option>
-            <option value="good">Good</option>
-            <option value="fair">Fair</option>
-          </select>
-        </div>
+              </div>
+            </div>
 
-        {/* Condition Photos */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
-            Condition Photos
-          </label>
-
-          {/* 隐藏的 input */}
-          <input
-            type="file"
-            id="condition-upload"
-            accept="image/*"
-            multiple
-            onChange={(e) => {
-              const files = Array.from(e.target.files || []);
-              setForm((prev) => ({
-                ...prev,
-                conditionImages: [...prev.conditionImages, ...files],
-              }));
-            }}
-            className="hidden"
-          />
-
-          {/* upload button */}
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            onClick={() => document.getElementById("condition-upload")?.click()}
-          >
-            Upload Images
-          </Button>
-
-          {/* preview */}
-          <div className="flex gap-2 mt-2 flex-wrap">
-            {form.conditionImages.map((file, index) => (
-              <img
-                key={index}
-                src={URL.createObjectURL(file)}
-                alt={`Condition ${index + 1}`}
-                className="h-20 w-16 object-cover rounded border"
-              />
-            ))}
-          </div>
-        </div>
-
-
-        {/* Deposit Price */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
-            Deposit Fee*
-          </label>
-          <div className="flex items-center gap-2">
+            {/* Title En */}
             <Input
-              name="depositPrice"
-              value={form.depositPrice}
+              label="Title - En*"
+              name="titleEn"
+              value={form.titleEn}
               onChange={handleChange}
-              placeholder="AU$"
               required
             />
+
+            {/* Author */}
+            <Input
+              label="Author*"
+              name="author"
+              value={form.author}
+              onChange={handleChange}
+              required
+            />
+
+            {/* Category */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Category*
+              </label>
+              <select
+                name="category"
+                value={form.category}
+                onChange={handleChange}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2"
+                required
+              >
+                <option value="">Please choose a category</option>
+                <option value="Fiction">Fiction</option>
+                <option value="Sci-Fi">Sci-Fi</option>
+                <option value="Non-Fiction">Non-Fiction</option>
+              </select>
+            </div>
+
+            {/* Tags */}
+            <Input
+              label="Tags (separate by ,)"
+              name="Tags"
+              value={form.tags}
+              onChange={handleChange}
+            />
+
+            {/* ISBN */}
+            <Input
+              label="ISBN"
+              name="isbn"
+              value={form.isbn}
+              onChange={handleChange}
+              placeholder="Optional-International Standard Book Number"
+            />
+
+            {/* Publish Year */}
+            <Input
+              label="Publish Year"
+              name="publishYear"
+              value={form.publishYear}
+              onChange={handleChange}
+              placeholder="e.g. 2020"
+            />
+
+            {/* Cover Image */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Cover Image
+              </label>
+
+              <div className="flex items-center gap-4">
+                {/* 隐藏的 input */}
+                <input
+                  type="file"
+                  id="cover-upload"
+                  accept="image/*"
+                  onChange={handleFileChange}
+                  className="hidden"
+                />
+
+                {/* upload button */}
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => document.getElementById("cover-upload")?.click()}
+                >
+                  Upload Image
+                </Button>
+
+                {/* preview */}
+                {form.coverImage && (
+                  <img
+                    src={URL.createObjectURL(form.coverImage)}
+                    alt="Preview"
+                    className="h-20 w-16 object-cover rounded border"
+                  />
+                )}
+              </div>
+            </div>
+          </div>
+
+          {/* 右栏：成色 / 交易设置 / 配送 */}
+          <div className="lg:w-1/2 lg:pl-8 space-y-6">
+
+            {/* Description */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Description*
+              </label>
+              <textarea
+                name="description"
+                value={form.description}
+                onChange={handleChange}
+                rows={4}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2 focus:ring-2 focus:ring-black"
+                required
+              />
+            </div>
+
+            {/* Condition */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Condition*
+              </label>
+              <select
+                name="condition"
+                value={form.condition}
+                onChange={handleChange}
+                className="w-full border border-gray-300 rounded-lg px-3 py-2"
+                required
+              >
+                <option value="new">New</option>
+                <option value="like-new">Like New</option>
+                <option value="good">Good</option>
+                <option value="fair">Fair</option>
+              </select>
+            </div>
+
+            {/* Condition Photos */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Condition Photos
+              </label>
+
+              {/* 隐藏的 input */}
+              <input
+                type="file"
+                id="condition-upload"
+                accept="image/*"
+                multiple
+                onChange={(e) => {
+                  const files = Array.from(e.target.files || []);
+                  setForm((prev) => ({
+                    ...prev,
+                    conditionImages: [...prev.conditionImages, ...files],
+                  }));
+                }}
+                className="hidden"
+              />
+
+              {/* upload button */}
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => document.getElementById("condition-upload")?.click()}
+              >
+                Upload Images
+              </Button>
+
+              {/* preview */}
+              <div className="flex gap-2 mt-2 flex-wrap">
+                {form.conditionImages.map((file, index) => (
+                  <img
+                    key={index}
+                    src={URL.createObjectURL(file)}
+                    alt={`Condition ${index + 1}`}
+                    className="h-20 w-16 object-cover rounded border"
+                  />
+                ))}
+              </div>
+            </div>
+
+            <hr className="my-6 border-gray-300" />
+
+            {/* Trading Way */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Trading Way* (at least one)
+              </label>
+
+              <div className="space-y-4">
+                {/* Sell 区块 */}
+                <div className="space-y-2">
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      name="canSell"
+                      checked={form.canSell}
+                      onChange={handleChange}
+                    />
+                    Sell
+                  </label>
+
+                  {/* 仅当 canSell = true 时显示 & 必填 */}
+                  {form.canSell && (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                      <Input
+                        label="Sale Price*"
+                        name="salePrice"
+                        value={form.salePrice}
+                        onChange={handleChange}
+                        placeholder="AU$"
+                        required={form.canSell}
+                      />
+                    </div>
+                  )}
+                </div>
+
+                {/* Rent 区块 */}
+                <div className="space-y-2">
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      name="canRent"
+                      checked={form.canRent}
+                      onChange={handleChange}
+                    />
+                    Lend Out
+                  </label>
+
+                  {/* 仅当 canRent = true 时显示 & 必填 */}
+                  {form.canRent && (
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                      <Input
+                        label="Deposit Fee*"
+                        name="deposit"
+                        value={form.deposit}
+                        onChange={handleChange}
+                        placeholder="AU$"
+                        required={form.canRent}
+                      />
+                      <Input
+                        label="Lend Duration*"
+                        name="lendDuration"
+                        value={form.lendDuration}
+                        onChange={handleChange}
+                        placeholder="Days"
+                        required={form.canRent}
+                      />
+                    </div>
+                  )}
+                </div>
+              </div>
+
+              {showErrors && !(form.canRent || form.canSell) && (
+                <p className="text-sm text-red-600 mt-1">
+                  Please select at least one option
+                </p>
+              )}
+            </div>
+
+
+            {/* Delivery Method */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                Delivery Method*
+              </label>
+
+              <div className="flex gap-6">
+                <label className="flex items-center gap-2">
+                  <input
+                    type="radio"
+                    name="deliveryMethod"
+                    value="post"
+                    checked={form.deliveryMethod === "post"}
+                    onChange={handleChange}
+                  />
+                  Post
+                </label>
+
+                <label className="flex items-center gap-2">
+                  <input
+                    type="radio"
+                    name="deliveryMethod"
+                    value="pickup"
+                    checked={form.deliveryMethod === "pickup"}
+                    onChange={handleChange}
+                  />
+                  Pickup
+                </label>
+
+                <label className="flex items-center gap-2">
+                  <input
+                    type="radio"
+                    name="deliveryMethod"
+                    value="both"
+                    checked={form.deliveryMethod === "both"}
+                    onChange={handleChange}
+                  />
+                  Both
+                </label>
+              </div>
+
+              {showErrors && !form.deliveryMethod && (
+                <p className="text-sm text-red-600 mt-1">Please choose a delivery method</p>
+              )}
+            </div>
+
           </div>
         </div>
 
-        {/* Lend Duration */}
-        <div className="flex items-center gap-2">
-          <Input
-            label="Lend Duration*"
-            name="lendDuration"
-            value={form.lendDuration}
-            onChange={handleChange}
-            placeholder="Days"
-            required
-          />
-        </div>
-
-        {/* Shipping Way */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-2">
-            Shipping Way* (at least one)
-          </label>
-          <div className="flex gap-4">
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                name="shippingPickup"
-                checked={form.shippingPickup}
-                onChange={handleChange}
-              />
-              Self Pickup
-            </label>
-            <label className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                name="shippingDelivery"
-                checked={form.shippingDelivery}
-                onChange={handleChange}
-              />
-              Delivery
-            </label>
+        {/* 提交区：占满两列 */}
+        <div className="lg:col-span-2">
+          <hr className="my-4 border-gray-200" />
+          <div className="flex justify-end">
+            <Button type="submit" variant="primary" size="md" className="w-full sm:w-auto">
+              Submit
+            </Button>
           </div>
-          {showErrors && !(form.shippingPickup || form.shippingDelivery) && (
-            <p className="text-sm text-red-600 mt-1">
-              Please select at least one option
-            </p>
-          )}
-
         </div>
 
-
-        {/* Submit */}
-        <div className="flex justify-end">
-          <Button type="submit" variant="primary" size="md" fullWidth>
-            Submit
-          </Button>
-        </div>
       </form>
     </div>
   );

--- a/frontendNext/app/profile/edit/page.tsx
+++ b/frontendNext/app/profile/edit/page.tsx
@@ -11,13 +11,14 @@ import Select from "@/app/components/ui/Select";
 import type { User } from "@/app/types/user";
 import Avatar from "@/app/components/ui/Avatar";
 import { toast } from "sonner";
-import { updateUser } from "../../../utils/auth";
+import { updateUser } from "@/utils/auth";
 
 
 const emptyUser: User = {
   id: "temp",
   firstName: "",
   lastName: "",
+  name: "",
   email: "",
   phoneNumber: "",
   dateOfBirth: { month: "", day: "", year: "" },
@@ -67,7 +68,7 @@ const handleSubmit = async (e: React.FormEvent) => {
   setIsLoading(true);
 
   try {
-    // 拼接全名
+    // 拼接全名to name
     const payload = {
       ...profileData,
       name: `${profileData.firstName} ${profileData.lastName}`.trim(),
@@ -75,14 +76,14 @@ const handleSubmit = async (e: React.FormEvent) => {
 
     const result = await updateUser(payload);
 
-    console.log("✅ Profile updated:", result);
+    console.log("Profile updated:", result);
     toast.success("Profile updated successfully!");
 
     window.dispatchEvent(new Event("auth-changed"));
     router.push("/profile");
   } catch (error) {
     toast.error(error instanceof Error ? error.message : "Update failed");
-    console.error("❌ Failed to update profile:", error);
+    console.error("Failed to update profile:", error);
   } finally {
     setIsLoading(false);
   }

--- a/frontendNext/app/types/user.ts
+++ b/frontendNext/app/types/user.ts
@@ -14,31 +14,36 @@ export interface Coordinates {
 export interface User {
   id: string;
 
-  // 基本信息
+  // basic info
   firstName: string;
   lastName: string;
+  name: string;
   email: string;
   phoneNumber?: string;
   dateOfBirth?: DateOfBirth;
 
-  // 地址信息
+  // address
   country: string;
   streetAddress: string;
   city: string;
   state: string;
   zipCode: string;
-  coordinates?: Coordinates;  // 经纬度，方便计算距离
-  maxDistance?: number;       // 借书的最大距离（公里）
+  coordinates?: Coordinates;  // GPS
+  maxDistance?: number;       // max lend distance（km）
 
-  // 头像
-  avatar?: string;           // 从 API 获取的头像 URL
-  profilePicture?: string;   // 本地上传的 base64
+  // profile pic
+  avatar?: string;           // default
+  profilePicture?: string;   // user upload
 
-  // 系统信息
+  // sys
   createdAt: Date;
 
-  // 社交 / 数据统计
-  bio?: string;               // 用户简介
-  preferredLanguages?: string[]; // 偏好语言
+  // social data
+  bio?: string;
+  preferredLanguages?: string[];
+}
 
+// rating
+export interface UserWithRating extends User {
+  rating: number;
 }

--- a/frontendNext/utils/auth.tsx
+++ b/frontendNext/utils/auth.tsx
@@ -1,6 +1,6 @@
 import axios from "axios";
 import type { User } from "@/app/types/user";
-
+import { Book } from "@/app/types/book";
 
 
 // API Configuration
@@ -27,6 +27,8 @@ interface RegisterData {
 
 interface UserData {
   id: string;
+  firstName: string;
+  lastName: string;
   name: string;
   email: string;
   location: string;
@@ -171,7 +173,7 @@ export const initAuth = () => {
 };
 
 // Get current user information from API
-export const getCurrentUser = async (): Promise<UserData | null> => {
+export const getCurrentUser = async (): Promise<User | null> => {
   const token = getToken();
   if (!token) return null;
 
@@ -184,31 +186,46 @@ export const getCurrentUser = async (): Promise<UserData | null> => {
     });
 
     const userData = response.data;
-    return {
+
+    const user: User = {
       id: userData.id,
+      firstName: userData.firstName,
+      lastName: userData.lastName,
       name: userData.name,
       email: userData.email,
-      location: userData.location,
-      phoneNumber: userData.phoneNumber || '',
-      address: userData.address || '',
-      city: userData.city || '',
-      state: userData.state || '',
-      zipCode: userData.zipCode || '',
+      phoneNumber: userData.phoneNumber || undefined,
+      dateOfBirth: userData.dateOfBirth || undefined,
+
+      country: userData.country,
+      streetAddress: userData.streetAddress,
+      city: userData.city,
+      state: userData.state,
+      zipCode: userData.zipCode,
+      coordinates: userData.coordinates || undefined,
+      maxDistance: userData.maxDistance || undefined,
+
       avatar:
         userData.avatar ||
         `https://ui-avatars.com/api/?name=${encodeURIComponent(
           userData.name
         )}&background=f97316&color=fff`,
-      createdAt: userData.createdAt,
+      profilePicture: userData.profilePicture || undefined,
+
+      createdAt: new Date(userData.createdAt),
+
+      bio: userData.bio || undefined,
+      preferredLanguages: userData.preferredLanguages || undefined,
     };
+
+    return user;
   } catch (error) {
     console.error("Failed to get user info:", error);
-    // Clear invalid token if API call fails
     localStorage.removeItem("access_token");
     delete axios.defaults.headers.common["Authorization"];
     return null;
   }
 };
+
 
 // Update user profile
 export const updateUser = async (user: User) => {
@@ -229,6 +246,30 @@ export const updateUser = async (user: User) => {
     return response.data; // 返回更新后的用户数据
   } catch (error) {
     console.error("Update API failed:", error);
+    throw error;
+  }
+};
+
+// start lending - save a new book
+export const createBook = async (book: Book) => {
+  const API_URL = getApiUrl();
+
+  try {
+    const response = await axios.post(
+      `${API_URL}/api/v1/books`,
+      book,
+      {
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${localStorage.getItem("access_token")}`,
+        },
+        withCredentials: true,
+      }
+    );
+
+    return response.data; // 返回创建后的书籍
+  } catch (error) {
+    console.error("Create Book API (JSON) failed:", error);
     throw error;
   }
 };


### PR DESCRIPTION
### Background

* Introduced a new feature to support creating and managing books from the frontend.
* Previously, the frontend did not integrate with the FastAPI `/api/v1/books` CRUD endpoints.

### Changes

1. **New book listing form page**

   * Implemented a form aligned with the backend `Book` schema, including fields such as `titleOr`, `titleEn`, `originalLanguage`, `author`, `category`, `description`, `condition`, `tags`, `isbn`, `publishYear`, `salePrice`, `deposit`, `maxLendingDays`, `deliveryMethod`, `canRent`, and `canSell`.
   * Added support for uploading a cover image (`coverImage`) and condition images (`conditionImages`).
   * Added validation: at least one trading option (rent or sell) must be selected, and related fields are required.

2. **API integration**

   * Added a `createBook` method in `utils/auth.tsx` (or `services/books.ts`) to call the backend `POST /api/v1/books` endpoint.
   * Integrated with authentication using `Authorization: Bearer token`.

3. **User association**

   * Automatically attaches `ownerId = currentUser.id` when creating a book, retrieved via `getCurrentUser`.

4. **UI and interactions**

   * Shows a success message “Book has been listed successfully” after creation.
   * Redirects to the book detail page (`/books/{id}`) upon successful submission.
   * Improved form layout: two-column design with vertical divider for better readability.

### How to Test

* Login and navigate to `/lend` page.
* Fill in the required fields and submit the form.
* Confirm that the backend successfully returns the created book.
* Verify in the database/Swagger UI that the new book record exists.
