### PR TITLE
Created complaint API

### DIFF
--- a/fastapi/main.py
+++ b/fastapi/main.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from routes.upload import router as upload_router
 from routes.books import router as books_router
 from routes.cart import router as cart_router
-
+from routes.complaints import router as complaints_router  # routes/complaints
 
 # Create FastAPI app
 app = FastAPI(
@@ -49,6 +49,9 @@ app.include_router(books_router)
 
 # cart router
 app.include_router(cart_router)
+
+# complaints router
+app.include_router(complaints_router)
 
 @app.get("/")
 async def root():

--- a/fastapi/models/complaint.py
+++ b/fastapi/models/complaint.py
@@ -1,0 +1,33 @@
+from sqlalchemy import Column, String, Text, DateTime, Enum, ForeignKey
+from sqlalchemy.sql import func
+from models.base import Base
+
+COMPLAINT_STATUS_ENUM = ("pending", "investigating", "resolved", "closed")
+COMPLAINT_TYPE_ENUM   = ("book-condition", "delivery", "user-behavior", "other")
+
+class Complaint(Base):
+    __tablename__ = "complaint"
+
+    id              = Column(String(36), primary_key=True)
+    order_id        = Column(String(36), nullable=True)  # TODO: Modify when order list/table is created
+    complainant_id  = Column(String(25), ForeignKey("users.user_id", ondelete="CASCADE"), nullable=False, index=True)
+    respondent_id   = Column(String(25), ForeignKey("users.user_id", ondelete="SET NULL"), nullable=True, index=True)
+
+    type            = Column(Enum(*COMPLAINT_TYPE_ENUM, name="complaint_type_enum"), nullable=False)
+    subject         = Column(String(255), nullable=False)
+    description     = Column(Text, nullable=False)
+
+    status          = Column(Enum(*COMPLAINT_STATUS_ENUM, name="complaint_status_enum"), nullable=False, default="pending", index=True)
+    admin_response  = Column(Text, nullable=True)
+
+    created_at      = Column(DateTime, server_default=func.now(), nullable=False, index=True)
+    updated_at      = Column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)
+
+class ComplaintMessage(Base):
+    __tablename__ = "complaint_message"
+
+    id           = Column(String(36), primary_key=True)
+    complaint_id = Column(String(36), ForeignKey("complaint.id", ondelete="CASCADE"), nullable=False, index=True)
+    sender_id    = Column(String(25), ForeignKey("users.user_id", ondelete="CASCADE"), nullable=False, index=True)
+    body         = Column(Text, nullable=False)
+    created_at   = Column(DateTime, server_default=func.now(), nullable=False)

--- a/fastapi/routes/complaints.py
+++ b/fastapi/routes/complaints.py
@@ -1,0 +1,137 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from typing import Optional, List, Literal
+from sqlalchemy.orm import Session
+
+from core.dependencies import get_db, get_current_user
+from models.user import User as UserModel
+from models.complaint import Complaint, ComplaintMessage
+from services.complaint_service import ComplaintService
+
+from pydantic import BaseModel, constr
+from typing import Optional, Literal
+
+router = APIRouter(prefix="/complaints", tags=["Complaint"])
+
+# ------ Helpers to match frontend field names ------
+def _to_read(c: Complaint) -> dict:
+    return {
+        "id": c.id,
+        "orderId": c.order_id,
+        "complainantId": c.complainant_id,
+        "respondentId": c.respondent_id,
+        "type": c.type,
+        "subject": c.subject,
+        "description": c.description,
+        "status": c.status,
+        "adminResponse": c.admin_response,
+        "createdAt": c.created_at,
+        "updatedAt": c.updated_at,
+    }
+
+def _msg_to_read(m: ComplaintMessage) -> dict:
+    return {
+        "id": m.id,
+        "complaintId": m.complaint_id,
+        "senderId": m.sender_id,
+        "body": m.body,
+        "createdAt": m.created_at,
+    }
+
+# ------ Create ------
+class ComplaintCreateBody(BaseModel):
+    orderId: Optional[str] = None
+    respondentId: Optional[str] = None
+    type: Literal["book-condition","delivery","user-behavior","other"]
+    subject: constr(min_length=1, max_length=255)
+    description: constr(min_length=1)
+
+class MessageCreate(BaseModel):
+    body: constr(min_length=1)
+
+
+class AdminResolveBody(BaseModel):
+    status: Optional[Literal["resolved","closed","investigating"]] = None
+    adminResponse: Optional[str] = None
+
+@router.post("", status_code=201)
+def create_complaint(
+    body: ComplaintCreateBody,
+    db: Session = Depends(get_db),
+    user: UserModel = Depends(get_current_user),
+):
+    c = ComplaintService.create(
+        db,
+        complainant_id=user.user_id,
+        order_id=body.orderId,
+        respondent_id=body.respondentId,
+        type=body.type,
+        subject=body.subject,
+        description=body.description,
+    )
+    return _to_read(c)
+
+
+# ------ List ------
+@router.get("")
+def list_complaints(
+    status: Optional[str] = Query(None),
+    role: Optional[Literal["mine","admin"]] = Query("mine"),
+    db: Session = Depends(get_db),
+    user: UserModel = Depends(get_current_user),
+):
+    if role == "admin" and user.user_id != "admin":  # TODO: Change the admin to a proper judging logic
+        raise HTTPException(status_code=403, detail="Admin only")
+    if role == "admin":                              # TODO: Change the admin to a proper judging logic
+        items = ComplaintService.list_all(db, status=status)
+    else:
+        items = ComplaintService.list_for_user(db, user_id=user.user_id, status=status)
+    return {"items": [_to_read(i) for i in items]}
+
+# ------ Get ------
+@router.get("/{complaint_id}")
+def get_complaint(
+    complaint_id: str,
+    db: Session = Depends(get_db),
+    user: UserModel = Depends(get_current_user),
+):
+    c = ComplaintService.get(db, complaint_id)
+    if user.user_id not in (c.complainant_id, c.respondent_id) and user.user_id != "admin":  # TODO: Change the admin to a proper judging logic
+        raise HTTPException(status_code=403, detail="Forbidden")
+    msgs = ComplaintService.list_messages(db, complaint_id=complaint_id)
+    return {"complaint": _to_read(c), "messages": [_msg_to_read(m) for m in msgs]}
+
+# ------ Messages ------
+@router.post("/{complaint_id}/messages", status_code=201)
+def add_message(
+    complaint_id: str,
+    body: MessageCreate,
+    db: Session = Depends(get_db),
+    user: UserModel = Depends(get_current_user),
+):
+    c = ComplaintService.get(db, complaint_id)
+    if user.user_id not in (c.complainant_id, c.respondent_id) and user.user_id != "admin":  # TODO: Change the admin to a proper judging logic
+        raise HTTPException(status_code=403, detail="Forbidden")
+    m = ComplaintService.add_message(
+        db, complaint_id=complaint_id, sender_id=user.user_id, body=body.body
+    )
+    return _msg_to_read(m)
+
+
+# ------ Admin actions ------
+@router.post("/{complaint_id}/resolve")
+def resolve_complaint(
+    complaint_id: str,
+    body: AdminResolveBody,
+    db: Session = Depends(get_db),
+    user: UserModel = Depends(get_current_user),
+):
+    if user.user_id != "admin":                 # TODO: Change the admin to a proper judging logic
+        raise HTTPException(status_code=403, detail="Admin only")
+    c = ComplaintService.admin_update(
+        db,
+        complaint_id=complaint_id,
+        status=body.status,
+        admin_response=body.adminResponse,
+    )
+    return _to_read(c)
+

--- a/fastapi/services/complaint_service.py
+++ b/fastapi/services/complaint_service.py
@@ -1,4 +1,3 @@
-# services/complaint_service.py
 from uuid import uuid4
 from typing import List, Optional, Tuple
 from sqlalchemy.orm import Session

--- a/fastapi/services/complaint_service.py
+++ b/fastapi/services/complaint_service.py
@@ -1,0 +1,113 @@
+# services/complaint_service.py
+from uuid import uuid4
+from typing import List, Optional, Tuple
+from sqlalchemy.orm import Session
+from sqlalchemy import select, or_, and_
+
+from models.complaint import Complaint, ComplaintMessage, COMPLAINT_STATUS_ENUM, COMPLAINT_TYPE_ENUM
+
+class ComplaintService:
+
+    # Create
+    @staticmethod
+    def create(
+        db: Session,
+        *,
+        complainant_id: str,
+        type: str,
+        subject: str,
+        description: str,
+        order_id: Optional[str] = None,
+        respondent_id: Optional[str] = None,
+    ) -> Complaint:
+        if type not in COMPLAINT_TYPE_ENUM:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=422, detail="Invalid complaint type")
+
+        c = Complaint(
+            id=str(uuid4()),
+            complainant_id=complainant_id,
+            respondent_id=respondent_id,
+            order_id=order_id,
+            type=type,
+            subject=subject,
+            description=description,
+            status="pending",
+        )
+        db.add(c)
+        db.commit()
+        db.refresh(c)
+        return c
+
+    # List (by user role)
+    @staticmethod
+    def list_for_user(
+        db: Session,
+        *,
+        user_id: str,
+        status: Optional[str] = None
+    ) -> List[Complaint]:
+        stmt = select(Complaint).where(
+            or_(Complaint.complainant_id == user_id, Complaint.respondent_id == user_id)
+        )
+        if status:
+            stmt = stmt.where(Complaint.status == status)
+        return db.execute(stmt.order_by(Complaint.created_at.desc())).scalars().all()
+
+    # Admin list
+    @staticmethod
+    def list_all(db: Session, *, status: Optional[str] = None) -> List[Complaint]:
+        stmt = select(Complaint)
+        if status:
+            stmt = stmt.where(Complaint.status == status)
+        return db.execute(stmt.order_by(Complaint.created_at.desc())).scalars().all()
+
+    # Get (with permission check deferred to router)
+    @staticmethod
+    def get(db: Session, complaint_id: str) -> Complaint:
+        c = db.get(Complaint, complaint_id)
+        if not c:
+            from fastapi import HTTPException
+            raise HTTPException(status_code=404, detail="Complaint not found")
+        return c
+
+    # Update status / admin response
+    @staticmethod
+    def admin_update(
+        db: Session,
+        *,
+        complaint_id: str,
+        status: Optional[str] = None,
+        admin_response: Optional[str] = None
+    ) -> Complaint:
+        c = ComplaintService.get(db, complaint_id)
+        if status:
+            if status not in COMPLAINT_STATUS_ENUM:
+                from fastapi import HTTPException
+                raise HTTPException(status_code=422, detail="Invalid status")
+            c.status = status
+        if admin_response is not None:
+            c.admin_response = admin_response
+        db.add(c)
+        db.commit()
+        db.refresh(c)
+        return c
+
+    # Messages
+    @staticmethod
+    def add_message(db: Session, *, complaint_id: str, sender_id: str, body: str) -> ComplaintMessage:
+        ComplaintService.get(db, complaint_id)  # ensure exists
+        m = ComplaintMessage(
+            id=str(uuid4()),
+            complaint_id=complaint_id,
+            sender_id=sender_id,
+            body=body.strip()
+        )
+        db.add(m)
+        db.commit()
+        db.refresh(m)
+        return m
+
+    @staticmethod
+    def list_messages(db: Session, *, complaint_id: str) -> List[ComplaintMessage]:
+        return db.query(ComplaintMessage).filter(ComplaintMessage.complaint_id == complaint_id).order_by(ComplaintMessage.created_at.asc()).all()


### PR DESCRIPTION
**_IMPORTANT: I left some 'TODO' comments for further development_**
E.g., 
- Order table / list haven't been created so the `order_id` attributes is `nullable` right now
- Some actions such as `resolve complaint` require `Admin` user id, there is no such "Role-Based Access Control" mechanics so I created a temporary admin account for testing:
    - user_id: 'admin'
    - name: 'Administrator'
    - email: 'admin@test.com'
    - password: 'swag123'
Use it if you need it.

There are FIVE APIs created:
<img width="1357" height="312" alt="image" src="https://github.com/user-attachments/assets/366869cb-1062-445e-95dc-d9e8598b2497" />

For the GET list complaints, 
- If role=mine, it shows complaints related to the current user (as complainant or respondent).
- If role=admin, it shows all complaints (requires admin user). -> You need admin account for this. You can filter by status (pending, investigating, resolved, closed).

For the /resolve route, you'll need the `admin` role to response to complaint change the status.


